### PR TITLE
Add endpoint config and enable to run test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,13 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.2"
-    provided "org.embulk:embulk-core:0.8.2"
+    compile  "org.embulk:embulk-core:0.8.8"
+    provided "org.embulk:embulk-core:0.8.8"
     compile "com.amazonaws:aws-java-sdk-dynamodb:1.10.50"
 
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.8.2:tests"
-    testCompile "org.embulk:embulk-standards:0.8.2"
+    testCompile "org.embulk:embulk-core:0.8.8:tests"
+    testCompile "org.embulk:embulk-standards:0.8.8"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {
@@ -53,7 +53,7 @@ task checkstyle(type: Checkstyle) {
     source = sourceSets.main.allJava + sourceSets.test.allJava
 }
 
-task gem(type: JRubyExec, dependsOn: ["build", "gemspec", "classpath"]) {
+task gem(type: JRubyExec, dependsOn: ["assemble", "gemspec", "classpath"]) {
     jrubyArgs "-rrubygems/gem_runner", "-eGem::GemRunner.new.run(ARGV)", "build"
     script "build/gemspec"
     doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "pkg") }

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
@@ -79,6 +79,24 @@ public class DynamodbOutputPlugin
         @Config("max_put_items")
         @ConfigDefault("25")
         int getMaxPutItems();
+
+        @Config("endpoint")
+        @ConfigDefault("null")
+        Optional<String> getEndpoint();
+
+        @Config("primary_key")
+        String getPrimaryKey();
+
+        @Config("primary_key_type")
+        String getPrimaryKeyType();
+
+        @Config("sort_key")
+        @ConfigDefault("null")
+        Optional<String> getSortKey();
+
+        @Config("sort_key_type")
+        @ConfigDefault("null")
+        Optional<String> getSortKeyType();
     }
 
     private final Logger log;

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
@@ -85,10 +85,10 @@ public class DynamodbOutputPlugin
         Optional<String> getEndpoint();
 
         @Config("primary_key")
-        String getPrimaryKey();
+        Optional<String> getPrimaryKey();
 
         @Config("primary_key_type")
-        String getPrimaryKeyType();
+        Optional<String> getPrimaryKeyType();
 
         @Config("sort_key")
         @ConfigDefault("null")
@@ -123,7 +123,11 @@ public class DynamodbOutputPlugin
             log.info(String.format("Executing plugin with '%s' mode", task.getMode()));
             task.setTable(dynamoDbUtils.generateTableName(task.getTable()));
             if (task.getAutoCreateTable()) {
-                dynamoDbUtils.createTable(dynamoDB, task);
+                if (task.getPrimaryKey().isPresent() && task.getPrimaryKeyType().isPresent()) {
+                    dynamoDbUtils.createTable(dynamoDB, task);
+                } else {
+                    throw new ConfigException("If auto_create_table is true, both primary_key and primary_key_type is necessary");
+                }
             }
             // Up to raised provisioned value
             dynamoDbUtils.updateTableProvision(dynamoDB, task, true);

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -287,7 +287,7 @@ public class DynamodbUtils
     private ArrayList<KeySchemaElement> getKeySchemaElements(DynamodbOutputPlugin.PluginTask task)
     {
         ArrayList<KeySchemaElement> keySchema = new ArrayList<>();
-        keySchema.add(new KeySchemaElement().withAttributeName(task.getPrimaryKey()).withKeyType(KeyType.HASH));
+        keySchema.add(new KeySchemaElement().withAttributeName(task.getPrimaryKey().get()).withKeyType(KeyType.HASH));
         if (task.getSortKey().isPresent()) {
             String sortKey = task.getSortKey().get();
             keySchema.add(new KeySchemaElement().withAttributeName(sortKey).withKeyType(KeyType.RANGE));
@@ -300,8 +300,8 @@ public class DynamodbUtils
         ArrayList<AttributeDefinition> attributeDefinitions = new ArrayList<>();
         attributeDefinitions.add(
                 new AttributeDefinition()
-                        .withAttributeName(task.getPrimaryKey())
-                        .withAttributeType(getAttributeType(task.getPrimaryKeyType())));
+                        .withAttributeName(task.getPrimaryKey().get())
+                        .withAttributeType(getAttributeType(task.getPrimaryKeyType().get())));
         if (task.getSortKey().isPresent()) {
             String sortKey = task.getSortKey().get();
             attributeDefinitions.add(

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -11,9 +11,16 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.document.TableWriteItems;
-import com.amazonaws.services.dynamodbv2.model.*;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.google.common.base.Optional;
-import com.google.common.util.concurrent.Runnables;
 import com.google.inject.Inject;
 import org.embulk.config.ConfigException;
 import org.embulk.config.UserDataException;
@@ -21,7 +28,11 @@ import org.embulk.spi.Exec;
 import org.jruby.embed.ScriptingContainer;
 import org.slf4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class DynamodbUtils
 {

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -11,13 +11,9 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB;
 import com.amazonaws.services.dynamodbv2.document.Item;
 import com.amazonaws.services.dynamodbv2.document.Table;
 import com.amazonaws.services.dynamodbv2.document.TableWriteItems;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
-import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.amazonaws.services.dynamodbv2.model.*;
 import com.google.common.base.Optional;
+import com.google.common.util.concurrent.Runnables;
 import com.google.inject.Inject;
 import org.embulk.config.ConfigException;
 import org.embulk.config.UserDataException;
@@ -25,10 +21,7 @@ import org.embulk.spi.Exec;
 import org.jruby.embed.ScriptingContainer;
 import org.slf4j.Logger;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class DynamodbUtils
 {
@@ -48,6 +41,10 @@ public class DynamodbUtils
                     getCredentialsProvider(task),
                     getClientConfiguration(task)
             ).withRegion(Regions.fromName(task.getRegion()));
+
+            if (task.getEndpoint().isPresent()) {
+                client.setEndpoint(task.getEndpoint().get());
+            }
 
             dynamoDB = new DynamoDB(client);
             dynamoDB.getTable(task.getTable());
@@ -169,9 +166,18 @@ public class DynamodbUtils
     protected void createTable(DynamoDB dynamoDB, DynamodbOutputPlugin.PluginTask task)
             throws InterruptedException
     {
+
+        ArrayList<KeySchemaElement> keySchema = getKeySchemaElements(task);
+        ArrayList<AttributeDefinition> attributeDefinitions = getAttributeDefinitions(task);
+        ProvisionedThroughput provisionedThroughput = new ProvisionedThroughput()
+                .withReadCapacityUnits(task.getReadCapacityUnits().get().getNormal().get())
+                .withWriteCapacityUnits(task.getWriteCapacityUnits().get().getNormal().get());
+
         dynamoDB.createTable(new CreateTableRequest()
                 .withTableName(task.getTable())
-                .withKeySchema()
+                .withKeySchema(keySchema)
+                .withAttributeDefinitions(attributeDefinitions)
+                .withProvisionedThroughput(provisionedThroughput)
         );
 
         Table table = dynamoDB.getTable(task.getTable());
@@ -267,6 +273,48 @@ public class DynamodbUtils
         return jruby.runScriptlet("Time.now.strftime('" + tableName + "')").toString();
     }
 
+    private ArrayList<KeySchemaElement> getKeySchemaElements(DynamodbOutputPlugin.PluginTask task)
+    {
+        ArrayList<KeySchemaElement> keySchema = new ArrayList<>();
+        keySchema.add(new KeySchemaElement().withAttributeName(task.getPrimaryKey()).withKeyType(KeyType.HASH));
+        if (task.getSortKey().isPresent()) {
+            String sortKey = task.getSortKey().get();
+            keySchema.add(new KeySchemaElement().withAttributeName(sortKey).withKeyType(KeyType.RANGE));
+        }
+        return keySchema;
+    }
+
+    private ArrayList<AttributeDefinition> getAttributeDefinitions(DynamodbOutputPlugin.PluginTask task)
+    {
+        ArrayList<AttributeDefinition> attributeDefinitions = new ArrayList<>();
+        attributeDefinitions.add(
+                new AttributeDefinition()
+                        .withAttributeName(task.getPrimaryKey())
+                        .withAttributeType(getAttributeType(task.getPrimaryKeyType())));
+        if (task.getSortKey().isPresent()) {
+            String sortKey = task.getSortKey().get();
+            attributeDefinitions.add(
+                    new AttributeDefinition()
+                            .withAttributeName(sortKey)
+                            .withAttributeType(getAttributeType(task.getSortKeyType().get())));
+        }
+        return attributeDefinitions;
+    }
+
+    private ScalarAttributeType getAttributeType(String type)
+    {
+        switch (type.toLowerCase()) {
+            case "string":
+                return ScalarAttributeType.S;
+            case "number":
+                return ScalarAttributeType.N;
+            case "binary":
+                return ScalarAttributeType.B;
+            default:
+                throw new UnknownScalarAttributeTypeException(type + " is invalid key type");
+        }
+    }
+
     public class ConnectionException extends RuntimeException implements UserDataException
     {
         protected ConnectionException()
@@ -279,6 +327,23 @@ public class DynamodbUtils
         }
 
         public ConnectionException(Throwable cause)
+        {
+            super(cause);
+        }
+    }
+
+    public class UnknownScalarAttributeTypeException extends RuntimeException implements UserDataException
+    {
+        protected UnknownScalarAttributeTypeException()
+        {
+        }
+
+        public UnknownScalarAttributeTypeException(String message)
+        {
+            super(message);
+        }
+
+        public UnknownScalarAttributeTypeException(Throwable cause)
         {
             super(cause);
         }

--- a/src/test/java/org/embulk/output/dynamodb/TestDynamodbOutputPlugin.java
+++ b/src/test/java/org/embulk/output/dynamodb/TestDynamodbOutputPlugin.java
@@ -34,10 +34,6 @@ import java.util.Map;
 
 public class TestDynamodbOutputPlugin
 {
-    private static String DYNAMO_REGION;
-    private static String DYNAMO_TABLE;
-    private static String DYNAMO_ACCESS_KEY_ID;
-    private static String DYNAMO_SECRET_ACCESS_KEY;
     private static String PATH_PREFIX;
 
     private MockPageOutput pageOutput;
@@ -45,13 +41,6 @@ public class TestDynamodbOutputPlugin
     @BeforeClass
     public static void initializeConstant()
     {
-        DYNAMO_REGION = System.getenv("DYNAMO_REGION") != null ? System.getenv("DYNAMO_REGION") : "";
-        DYNAMO_TABLE = System.getenv("DYNAMO_TABLE") != null ? System.getenv("DYNAMO_TABLE") : "";
-        DYNAMO_ACCESS_KEY_ID = System.getenv("DYNAMO_ACCESS_KEY_ID") != null ? System.getenv("DYNAMO_ACCESS_KEY_ID") : "";
-        DYNAMO_SECRET_ACCESS_KEY = System.getenv("DYNAMO_SECRET_ACCESS_KEY") != null ? System.getenv("DYNAMO_SECRET_ACCESS_KEY") : "";
-
-        assumeNotNull(DYNAMO_REGION, DYNAMO_TABLE, DYNAMO_ACCESS_KEY_ID, DYNAMO_SECRET_ACCESS_KEY);
-
         PATH_PREFIX = DynamodbOutputPlugin.class.getClassLoader().getResource("sample_01.csv").getPath();
     }
 
@@ -88,7 +77,7 @@ public class TestDynamodbOutputPlugin
     {
         ConfigSource config = config();
         DynamodbOutputPlugin.PluginTask task = config.loadConfig(PluginTask.class);
-        assertEquals(DYNAMO_REGION, task.getRegion());
+        assertEquals("us-west-1", task.getRegion());
     }
 
     @Test
@@ -204,11 +193,24 @@ public class TestDynamodbOutputPlugin
                 .set("parser", parserConfig(schemaConfig()))
                 .set("type", "dynamodb")
                 .set("mode", "upsert")
-                .set("region", DYNAMO_REGION)
-                .set("table", DYNAMO_TABLE)
+                .set("region", "us-west-1")
+                .set("table", "dummy")
+                .set("primary_key", "id")
+                .set("primary_key_type", "string")
+                .set("read_capacity_units", capacityUnitConfig())
+                .set("write_capacity_units", capacityUnitConfig())
                 .set("auth_method", "basic")
-                .set("access_key_id", DYNAMO_ACCESS_KEY_ID)
-                .set("secret_access_key", DYNAMO_SECRET_ACCESS_KEY);
+                .set("access_key_id", "dummy")
+                .set("secret_access_key", "dummy")
+                .set("endpoint", "http://localhost:8000");
+    }
+
+    private ImmutableMap<String, Object> capacityUnitConfig()
+    {
+        ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+        builder.put("normal", 5L);
+        builder.put("raise", 8L);
+        return builder.build();
     }
 
     private ImmutableMap<String, Object> inputConfig()

--- a/src/test/java/org/embulk/output/dynamodb/TestDynamodbOutputPlugin.java
+++ b/src/test/java/org/embulk/output/dynamodb/TestDynamodbOutputPlugin.java
@@ -1,9 +1,6 @@
 package org.embulk.output.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
-import com.amazonaws.services.dynamodbv2.document.ItemCollection;
-import com.amazonaws.services.dynamodbv2.document.ScanOutcome;
-import com.amazonaws.services.dynamodbv2.document.Table;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -25,12 +22,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeNotNull;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestDynamodbOutputPlugin
 {


### PR DESCRIPTION
## Changes
- Add endpoint config in order to use dynamodb-local.
- Add primary_key, sort_key config because `createTable` needs them
- Use dynamodb-local when developer run test.
- Fix `createTable` because current version doesn't set necessary parameters.
- Change `gem` task dependency from `build` to `assemble`
  - because that If developer doesn't have dynamodb-local, he cannot build gem, avoid it.
