### PR TITLE
Check if table exists before create table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@
       type: dynamodb
       table: table_%Y_%m
     ```
+- **primary_key** (string, required when use auto_create_table) primary key name
+- **primary_key_type** (string, required when use auto_create_table) primary key type
 - **write_capacity_units** (int optional) Provisioned write capacity units
     - **normal** (int optional) value that will be set after execution
     - **raise** (int optional) value that will be set before execution
@@ -178,6 +180,8 @@ out:
   secret_access_key: ABCXYZ123ABCXYZ123
   auto_create_table: true
   table: dynamotable
+  primary_key: id
+  primary_key_type: Number
   write_capacity_units:
     normal: 5
     raise: 20

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
@@ -85,9 +85,11 @@ public class DynamodbOutputPlugin
         Optional<String> getEndpoint();
 
         @Config("primary_key")
+        @ConfigDefault("null")
         Optional<String> getPrimaryKey();
 
         @Config("primary_key_type")
+        @ConfigDefault("null")
         Optional<String> getPrimaryKeyType();
 
         @Config("sort_key")

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -177,6 +177,11 @@ public class DynamodbUtils
     protected void createTable(DynamoDB dynamoDB, DynamodbOutputPlugin.PluginTask task)
             throws InterruptedException
     {
+        String tableName = task.getTable();
+        if (isExistsTable(dynamoDB, tableName)) {
+            log.info("Table[{}] is already exists", tableName);
+            return;
+        }
         ArrayList<KeySchemaElement> keySchema = getKeySchemaElements(task);
         ArrayList<AttributeDefinition> attributeDefinitions = getAttributeDefinitions(task);
         ProvisionedThroughput provisionedThroughput = new ProvisionedThroughput()
@@ -184,15 +189,15 @@ public class DynamodbUtils
                 .withWriteCapacityUnits(task.getWriteCapacityUnits().get().getNormal().get());
 
         dynamoDB.createTable(new CreateTableRequest()
-                .withTableName(task.getTable())
+                .withTableName(tableName)
                 .withKeySchema(keySchema)
                 .withAttributeDefinitions(attributeDefinitions)
                 .withProvisionedThroughput(provisionedThroughput)
         );
 
-        Table table = dynamoDB.getTable(task.getTable());
+        Table table = dynamoDB.getTable(tableName);
         table.waitForActive();
-        log.info(String.format("Created table '%s'", task.getTable()));
+        log.info("Created table[{}]", tableName);
     }
 
     protected void deleteTable(DynamoDB dynamoDB, String tableName)

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -213,7 +213,6 @@ public class DynamodbUtils
             throws InterruptedException
     {
         Table table = dynamoDB.getTable(tableName);
-        TableDescription description = null;
         try {
             switch (table.describe().getTableStatus()) {
                 case "CREATING":


### PR DESCRIPTION
v0.1.0 failed when `auto_create_table` set true and table already exists.
I added check logic if table exists there before creating table.

Additionally, Set defalut value `@ConfigDefault("null")` to `primary_key` and `primary_key_type`.
