### PR TITLE
Add validation for auto_create_table option

### DIFF
--- a/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
@@ -300,7 +300,8 @@ public class DynamodbOutputPlugin
                                         list.add(getRawFromValue(v));
                                     }
                                     item.withList(column.getName(), list);
-                                } else {
+                                }
+                                else {
                                     item.withJSON(column.getName(), jsonValue.toJson());
                                 }
                             }
@@ -314,26 +315,32 @@ public class DynamodbOutputPlugin
                         private Object getRawFromValue(Value value)
                         {
                             if (value.isBooleanValue()) {
-                                return ((BooleanValue)value).getBoolean();
-                            } else if (value.isStringValue()) {
+                                return ((BooleanValue) value).getBoolean();
+                            }
+                            else if (value.isStringValue()) {
                                 return value.toString();
-                            } else if (value.isIntegerValue()) {
-                                return ((IntegerValue)value).asLong();
-                            } else if (value.isFloatValue()) {
-                                return ((FloatValue)value).toDouble();
-                            } else if (value.isArrayValue()) {
+                            }
+                            else if (value.isIntegerValue()) {
+                                return ((IntegerValue) value).asLong();
+                            }
+                            else if (value.isFloatValue()) {
+                                return ((FloatValue) value).toDouble();
+                            }
+                            else if (value.isArrayValue()) {
                                 List<Object> list = new ArrayList<>();
                                 for (Value v : value.asArrayValue()) {
                                     list.add(getRawFromValue(v));
                                 }
                                 return list;
-                            } else if (value.isMapValue()) {
+                            }
+                            else if (value.isMapValue()) {
                                 Map<String, Object> map = new LinkedHashMap<>();
                                 for (Map.Entry<Value, Value> entry : value.asMapValue().entrySet()) {
                                     map.put(entry.getKey().toString(), getRawFromValue(entry.getValue()));
                                 }
                                 return map;
-                            } else if (value.isNilValue()) {
+                            }
+                            else if (value.isNilValue()) {
                                 return null;
                             }
                             throw new DataException("Record has invalid json column value");

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -111,6 +111,9 @@ public class DynamodbUtils
             if (!task.getPrimaryKey().isPresent() || !task.getPrimaryKeyType().isPresent()) {
                 throw new ConfigException("If auto_create_table is true, both primary_key and primary_key_type is necessary");
             }
+            if (!task.getReadCapacityUnits().isPresent() || !task.getWriteCapacityUnits().isPresent()) {
+                throw new ConfigException("If auto_create_table is true, 'read_capacity_units' and 'write_capacity_units' is required.");
+            }
         }
     }
 


### PR DESCRIPTION
When `auto_create_table` is true, both of `read_capacity_units` and `write_capacity_units` options are required.

Current version return following Exception when these options are not set.
This is not friendly for user. I fixed it.

```
Caused by: java.lang.IllegalStateException: Optional.get() cannot be called on an absent value
```
