### PR TITLE
HashKey/RangeKey table support at upsert_with_expression mode

### DIFF
--- a/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
@@ -199,7 +199,7 @@ public class DynamodbOutputPlugin
         private final String table;
         private final Mode mode;
         private final Optional<String> updateExpression;
-        private final String primaryKey;
+        private final List primaryKeyElements;
         private final int maxPutItems;
 
         public DynamodbPageOutput(PluginTask task, DynamoDB dynamoDB)
@@ -210,7 +210,7 @@ public class DynamodbOutputPlugin
             this.table = task.getTable();
             this.mode = task.getMode();
             this.updateExpression = task.getUpdateExpression();
-            this.primaryKey = (mode.equals(Mode.UPSERT_WITH_EXPRESSION)) ? dynamodbUtils.getPrimaryKeyName(dynamoDB, table) : null;
+            this.primaryKeyElements= (mode.equals(Mode.UPSERT_WITH_EXPRESSION)) ? dynamodbUtils.getPrimaryKey(dynamoDB, table) : null;
             this.maxPutItems = task.getMaxPutItems();
         }
 
@@ -400,7 +400,7 @@ public class DynamodbOutputPlugin
         public void updateItem(Item item)
         {
             try {
-                dynamodbUtils.updateItem(dynamoDB, table, item, primaryKey, updateExpression);
+                dynamodbUtils.updateItem(dynamoDB, table, item, primaryKeyElements, updateExpression);
                 totalWroteItemSize++;
                 if (totalWroteItemSize % 1000 == 0) {
                     log.info(String.format("Updated %s items", totalWroteItemSize));

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbOutputPlugin.java
@@ -210,7 +210,7 @@ public class DynamodbOutputPlugin
             this.table = task.getTable();
             this.mode = task.getMode();
             this.updateExpression = task.getUpdateExpression();
-            this.primaryKeyElements= (mode.equals(Mode.UPSERT_WITH_EXPRESSION)) ? dynamodbUtils.getPrimaryKey(dynamoDB, table) : null;
+            this.primaryKeyElements = (mode.equals(Mode.UPSERT_WITH_EXPRESSION)) ? dynamodbUtils.getPrimaryKey(dynamoDB, table) : null;
             this.maxPutItems = task.getMaxPutItems();
         }
 

--- a/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
+++ b/src/main/java/org/embulk/output/dynamodb/DynamodbUtils.java
@@ -212,7 +212,6 @@ public class DynamodbUtils
 
     protected List getPrimaryKey(DynamoDB dynamoDB, String tableName)
     {
-        log.debug("getPrimaryKey() called");
         Table table = dynamoDB.getTable(tableName);
         TableDescription description = table.describe();
         List<KeySchemaElement>  keyelements = description.getKeySchema();


### PR DESCRIPTION
I try to load HashKey/RangeKey defenishion table with upsert_with_expression mode.
but, it did not work.

so, I fix the code.

# example

## destination table
| uid(String,HK) | code(Number,RK) | count(Number) |
| --------------- |---------------:| -------------------- |
| u001 | 1 | 0 |
| u001 | 2 | 1 |
| u002 | 1 | 1 |

## load data
```
u001,1,1
u002,1,3
```

## update_expression
```
"ADD #count : count".
```

please merge this change
