### PR TITLE
Use ECS task role in auth_method 'instance' (and Upgrade aws-sdk version to 1.11.16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@
 
 - **instance**
     
-    Use EC2 instance profile
+    Use ECS task role or EC2 instance profile.
     
     ```yaml
     auth_method: instance

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.8"
     provided "org.embulk:embulk-core:0.8.8"
-    compile "com.amazonaws:aws-java-sdk-dynamodb:1.10.50"
+    compile "com.amazonaws:aws-java-sdk-dynamodb:1.11.16"
 
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.8:tests"

--- a/src/main/java/org/embulk/output/dynamodb/AwsCredentials.java
+++ b/src/main/java/org/embulk/output/dynamodb/AwsCredentials.java
@@ -7,8 +7,8 @@ import com.amazonaws.auth.AWSSessionCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.auth.profile.ProfilesConfigFile;
@@ -85,7 +85,7 @@ public abstract class AwsCredentials
                 reject(task.getSessionToken(), "session_token");
                 reject(task.getProfileFile(), "profile_file");
                 reject(task.getProfileName(), "profile_name");
-                return new InstanceProfileCredentialsProvider();
+                return new EC2ContainerCredentialsProviderWrapper();
 
             case "profile":
             {


### PR DESCRIPTION
Thanks for useful plugin to output into DynamoDB.

I would like to use ECS task role authentication to DynamoDB. (available in aws-java-sdk since version 1.11.16)

# Changes
- Upgrade aws-java-sdk-dynamodb version to 1.11.16
- Use ECS task role or EC2 instance profile in auth_method 'instance'

Thanks in advance.